### PR TITLE
Remove base64 from protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ message ChaincodeInput {
 
 }
 ```
-Chaintool deterministically maps functions declared within a CCI to an [encoded function name](#function-encoding), and expects the corresponding input parameter to be a base64 encoded protobuf message as the first and only arg string.
+Chaintool deterministically maps functions declared within a CCI to an [encoded function name](#function-encoding), and expects the corresponding input parameter to be a serialized protobuf message as the first and only arg string.
 
 Example:
 ```
@@ -323,7 +323,7 @@ Function naming follows the convention *interface-name/method-type/method-index*
 
 ### Output Protocol
 
-Standard chaincode protocol allows chaincode applications to return a string to a caller.  Chaintool managed applications will encode this string with a base64 encoded protobuf structure (when applicable).
+Standard chaincode protocol allows chaincode applications to return a byte-array payload to a caller.  Chaintool managed applications will encode this payload with a serialized protobuf structure (when applicable).
 
 ### Protobuf "hints"
 

--- a/examples/example02/client/nodejs/client.js
+++ b/examples/example02/client/nodejs/client.js
@@ -31,7 +31,7 @@ function createRequest(fcn, args) {
         chainId: 'testchainid',
         chaincodeId: 'mycc',
         fcn: fcn,
-        args: [args.toBase64()],
+        args: [args.toBuffer()],
         txId: tx_id,
         nonce: nonce
     };
@@ -93,7 +93,7 @@ function checkBalance(args) {
     return sendQuery('org.hyperledger.chaincode.example02/fcn/3',
                      new app.Entity(args))
         .then(function(results) {
-            return app.BalanceResult.decode64(results[0].toString('utf-8'));
+            return app.BalanceResult.decode(results[0]);
         });
 }
 

--- a/resources/generators/golang.stg
+++ b/resources/generators/golang.stg
@@ -37,11 +37,13 @@ var functionspec = regexp.MustCompile("([a-zA-Z0-9.]*)/fcn/([0-9]*)")
 // Initialization function, called only once
 func (self *stubHandler) Init(stub shim.ChaincodeStubInterface) pb.Response {
 
-	function, args := stub.GetFunctionAndParameters()
+	args := stub.GetArgs()
 
-	if len(args) != 1 {
-		return shim.Error("Expected exactly one argument")
+	if len(args) != 2 {
+		return shim.Error("Expected exactly two arguments")
 	}
+
+        function := string(args[0])
 
         if function != "init" {
                return shim.Error("Function must be \"init\"")
@@ -52,21 +54,21 @@ func (self *stubHandler) Init(stub shim.ChaincodeStubInterface) pb.Response {
                return shim.Error("Interface not found")
         }
 
-        return dispatcher.Dispatch(stub, 1, args[0])
+        return dispatcher.Dispatch(stub, 1, args[1])
 }
 
 // Callback representing the invocation of a chaincode
 func (self *stubHandler) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
 
-	function, args := stub.GetFunctionAndParameters()
+	args := stub.GetArgs()
 
-        var params string;
+        var params []byte;
 
-	if len(args) > 0 {
-		params = args[0]
+	if len(args) > 1 {
+		params = args[1]
 	}
 
-	dispatcher, index, err := self.decodeFunction(function)
+	dispatcher, index, err := self.decodeFunction(string(args[0]))
 	if err != nil {
 		return shim.Error(err.Error())
 	}
@@ -162,7 +164,7 @@ import (
 )
 
 type Dispatcher interface {
-     Dispatch(stub shim.ChaincodeStubInterface, function int, params string) pb.Response
+     Dispatch(stub shim.ChaincodeStubInterface, function int, params []byte) pb.Response
 }
 
 type Factory interface {
@@ -273,7 +275,6 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/shim"
         pb "github.com/hyperledger/fabric/protos/peer"
         "<base>/ccs/api"
-        "encoding/base64"
         "fmt"
 )
 
@@ -299,7 +300,7 @@ func (self *factoryImpl) Create(intf interface{}) (api.Dispatcher, error) {
      return &stubImpl{intf: intf.(CCInterface)}, nil
 }
 
-func (self *stubImpl) Dispatch(stub shim.ChaincodeStubInterface, function int, params string) pb.Response {
+func (self *stubImpl) Dispatch(stub shim.ChaincodeStubInterface, function int, params []byte) pb.Response {
         // Handle different functions
         switch {
         <dispatchfunctions(intf, intf.functions)>
@@ -336,7 +337,6 @@ package <intf.package>
 import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/chaincode/shim"
-        "encoding/base64"
         "fmt"
 )
 
@@ -369,17 +369,13 @@ case function == <func.index>:
 implementserver(intf, func) ::=
 <<
 
-func (self *stubImpl) proxy<func.name>(stub shim.ChaincodeStubInterface, _params string) pb.Response {
+func (self *stubImpl) proxy<func.name>(stub shim.ChaincodeStubInterface, _params []byte) pb.Response {
 
      var err error;
 
      <if(func.param)>
      params := &<func.param>{}
-     _pbinput, err := base64.StdEncoding.DecodeString(_params)
-     if (err != nil) {
-        return shim.Error(fmt.Sprintf("base64 decode error: %s", err))
-     }
-     err = proto.Unmarshal(_pbinput, params)
+     err = proto.Unmarshal(_params, params)
      if (err != nil) {
         return shim.Error(fmt.Sprintf("protobuf unmarshal error: %s", err))
      }
@@ -391,12 +387,11 @@ func (self *stubImpl) proxy<func.name>(stub shim.ChaincodeStubInterface, _params
      }
 
      <if(func.rettype)>
-     _pboutput, err := proto.Marshal(result)
+     _result, err := proto.Marshal(result)
      if (err != nil) {
         return shim.Error(fmt.Sprintf("protobuf marshal error: %s", err))
      }
-     _result := base64.StdEncoding.EncodeToString(_pboutput)
-     return shim.Success([]byte(_result))
+     return shim.Success(_result)
      <else>
      return shim.Success(nil)
      <endif>
@@ -420,24 +415,17 @@ func <func.name>(stub shim.ChaincodeStubInterface, chaincodeName string<if(func.
      args[0] = []byte(<compositename(intf, func)>)
 
      <if(func.param)>
-     _pboutput, err := proto.Marshal(params)
+     args[1], err = proto.Marshal(params)
      if (err != nil) {
           return <if(func.rettype)>nil, <endif>err
      }
-
-     args[1] = make([]byte, base64.StdEncoding.EncodedLen(len(_pboutput)))
-     base64.StdEncoding.Encode(args[1], _pboutput)
      <endif>
 
-      resp := stub.InvokeChaincode(chaincodeName, args)
+      resp := stub.InvokeChaincode(chaincodeName, args, "")
       if resp.Status \< shim.ERROR {
          <if(func.rettype)>
 	result := &<func.rettype>{}
-	_pbinput, err := base64.StdEncoding.DecodeString(string(resp.Payload))
-	if (err != nil) {
-	     return nil, fmt.Errorf("Error decoding base64 return value: %s", err)
-	}
-	err = proto.Unmarshal(_pbinput, result)
+	err = proto.Unmarshal(resp.Payload, result)
 	if (err != nil) {
 	     return nil, fmt.Errorf("Error unmarshalling return value: %s", err)
 	}


### PR DESCRIPTION
This was a leftover from when the fabric transport was string
based.  Since we can now send raw bytes, we might as well use
them since its more space and time efficient to avoid the base64
encode/decode cycle.

Signed-off-by: Greg Haskins <gregory.haskins@gmail.com>